### PR TITLE
Fix setUserId typo

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -165,19 +165,10 @@ const Amplitude = {
 
   /**
    * Set user id
-   * @param userID {String} required
+   * @param userID {String} or null required
    */
-  setUserId: function (userID) {
-    if(!userID) {
-      error('[setUserId] userID is required.');
-      return;
-    }
-    if(!isString(userId)) {
-      error('[setUserId] userID should be a string.');
-      return;
-    }
-
-    amplitude.getInstance().setUserId(userID);
+  setUserId: function (userId) {
+    amplitude.getInstance().setUserId(userId);
   },
 
   /**

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@
  * @package react-amplitude
  * @author  Rory Garand <rory@mettleup.com>
  */
-import {isFunction, isNil, isPlainObject, isString} from 'lodash';
+import {isFunction, isNil, isPlainObject, isString, isNull} from 'lodash';
 import {error, log, warn} from './utils/console';
 
 const _debug = false;
@@ -168,6 +168,10 @@ const Amplitude = {
    * @param userID {String} or null required
    */
   setUserId: function (userId) {
+    if(!isString(userId) && !isNull(userId)) {
+      warn('[setUserId] userId must be a string or null.');
+    }
+
     amplitude.getInstance().setUserId(userId);
   },
 


### PR DESCRIPTION
setUserId was always returning because of the mismatched userID and userId references in the returns. 

the api for setUserId requires string but also accepts null (https://amplitude.zendesk.com/hc/en-us/articles/115002889587-JavaScript-SDK-Reference)  

I propose removing the return requiring userId and string to allow for null.