### PR TITLE
Reducing the end npm bundle size by switching to use the single lodas…

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,11 @@
   },
   "homepage": "https://github.com/rorygarand/react-amplitude",
   "dependencies": {
-    "lodash": "^4.17.4"
+    "lodash.isfunction": "^3.0.8",
+    "lodash.isnil": "^4.0.0",
+    "lodash.isnull": "^3.0.0",
+    "lodash.isplainobject": "^4.0.6",
+    "lodash.isstring": "^4.0.1"
   },
   "devDependencies": {
     "babel-core": "^6.26.0",

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,11 @@
  * @package react-amplitude
  * @author  Rory Garand <rory@mettleup.com>
  */
-import {isFunction, isNil, isPlainObject, isString, isNull} from 'lodash';
+import isFunction from 'lodash.isfunction';
+import isNil from 'lodash.isnil';
+import isPlainObject from 'lodash.isplainobject';
+import isString from 'lodash.isstring';
+import isNull from 'lodash.isnull';
 import {error, log, warn} from './utils/console';
 
 const _debug = false;
@@ -17,12 +21,12 @@ const Amplitude = {
    * @param config {Object} optional
    * @param cb {Function} optional
    */
-  init: function (apiKey, userID, config, cb) {
+  init: function (apiKey, userId, config, cb) {
     if (!isString(apiKey)) {
       warn('[init] apiKey is required');
       return;
     }
-    if(!isNil(userID) && !isString(userID)) {
+    if(!isNil(userId) && !isString(userId)) {
       warn('[init] userId should be a string');
     }
     if(!isNil(config) && !isPlainObject(config)) {
@@ -165,7 +169,7 @@ const Amplitude = {
 
   /**
    * Set user id
-   * @param userID {String} or null required
+   * @param userId {String} or null required
    */
   setUserId: function (userId) {
     if(!isString(userId) && !isNull(userId)) {


### PR DESCRIPTION
…h modules

that are being used instead of the entire lodash library.

<img width="1026" alt="screen shot 2018-02-02 at 2 53 21 pm" src="https://user-images.githubusercontent.com/1375632/35758446-e8f57b90-0828-11e8-9bb2-8a4a96a74ce6.png">
^ that is the entire `lodash` lib being included within this lib, by allowing this PR, we can reduce that
by quite a lot as you only use 5 functions from lodash.

On another note, would love to become a core contributor to this library! I think you have created an awesome package and want to help maintain it and make it better. Let me know what you think!