### PR TITLE
support userId and config on init()

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -49,7 +49,7 @@ const Amplitude = {
     if(!n._iq.hasOwnProperty(e)){n._iq[e]={_q:[]};v(n._iq[e])}return n._iq[e]};e.amplitude=n;
     })(window,document);
 
-    amplitude.getInstance().init(apiKey);
+    amplitude.getInstance().init(apiKey, userId, config);
   },
 
   /**


### PR DESCRIPTION
React-amplitude's init seems to support userId and config but then doesn't pass them to the SDK. this minor change should remedy that.