### PR TITLE
Fix amplitude utility import

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -39,7 +39,7 @@ const Amplitude = {
     }
 
     if (isNil(window.amplitude)) {
-        require('./utils/amplitude')((window, document))
+      require("./utils/amplitude").default(window, document);
     }
 
     config = config || {};


### PR DESCRIPTION
Not 100% sure of this one but I've been running into issues with this operation after upgrading the npm package. I'm running into the situation where the amplitude utility export isn't unwrapping the default export so the initialization tanks.