### PR TITLE
Use amplitude v4.5.0

### DIFF
--- a/src/utils/amplitude.js
+++ b/src/utils/amplitude.js
@@ -3,7 +3,7 @@ export default function (e, t) {
     var r = t.createElement("script");
     r.type = "text/javascript";
     r.async = true;
-    r.src = "https://d24n15hnbwhuhn.cloudfront.net/libs/amplitude-4.1.0-min.gz.js";
+    r.src = "https://cdn.amplitude.com/libs/amplitude-4.5.0-min.gz.js";
     r.onload = function () {
         e.amplitude.runQueuedFunctions()
     };


### PR DESCRIPTION
Amplitude is encouraging all of our customers using our JavaScript SDK < v4.1.1 to update immediately in order to avoid possible data contamination. For more context, please see this [article](https://amplitude.zendesk.com/hc/en-us/articles/360019036051-11-1-2018-Pre-v-4-1-1-JS-SDK-Deprecation).

This PR updates the version used by react-amplitude and uses the `cdn.amplitude.com` hostname, as recommended by the Amplitude installation docs.